### PR TITLE
메모 삭제시 DOM에서 삭제하도록 로직 변경. 리펙토링.

### DIFF
--- a/src/main/java/com/zetta/memo/page/memo/MemoController.java
+++ b/src/main/java/com/zetta/memo/page/memo/MemoController.java
@@ -18,8 +18,9 @@ public class MemoController {
     }
 
     @PostMapping("/register")
-    public boolean insertMemo(@RequestBody MemoDTO memoDTO) {
-        return memoService.insertMemo(memoDTO);
+    public long insertMemo(@RequestBody MemoDTO memoDTO) {
+        memoService.insertMemo(memoDTO);
+        return memoDTO.getId();
     }
 
     @PutMapping("/update/{id}")

--- a/src/main/java/com/zetta/memo/page/memo/MemoMapper.java
+++ b/src/main/java/com/zetta/memo/page/memo/MemoMapper.java
@@ -7,7 +7,7 @@ import java.util.List;
 @Mapper
 public interface MemoMapper {
     List<MemoDTO> selectMemo(MemoDTO.Search search);
-    boolean insertMemo(MemoDTO memoDTO);
+    void insertMemo(MemoDTO memoDTO);
     boolean updateMemo(MemoDTO memoDTO);
     boolean deleteMemo(long id);
 }

--- a/src/main/java/com/zetta/memo/page/memo/MemoService.java
+++ b/src/main/java/com/zetta/memo/page/memo/MemoService.java
@@ -15,8 +15,8 @@ public class MemoService {
         return memoMapper.selectMemo(search);
     }
 
-    public boolean insertMemo(MemoDTO memoDTO) {
-        return memoMapper.insertMemo(memoDTO);
+    public void insertMemo(MemoDTO memoDTO) {
+        memoMapper.insertMemo(memoDTO);
     }
 
     public boolean updateMemo(MemoDTO memoDTO) {

--- a/src/main/resources/mybatis-mapper/MemoMapper.xml
+++ b/src/main/resources/mybatis-mapper/MemoMapper.xml
@@ -18,7 +18,7 @@
         </if>
     </select>
 
-    <insert id="insertMemo">
+    <insert id="insertMemo" useGeneratedKeys="true" keyProperty="id">
         insert into memo
             (
                 id

--- a/src/main/resources/static/js/memo2.js
+++ b/src/main/resources/static/js/memo2.js
@@ -16,7 +16,7 @@ window.onload = () => {
             memo = convertEnterToDiv($memoTextarea.value);
         }
         document.querySelector('#memo-output').insertAdjacentHTML('afterbegin', '<div class="memo-item"><div '
-        + 'class="memo-contents">' + memo + '</div><div class="memo-del-div"><button id="' 
+        + 'class="memo-contents">' + memo + '</div><div class="memo-del-div"><button id="memo-num-' 
         + memoId + '" class="memo-del-btn">삭제</button></div></div>');
 
         $memoTextarea.value = '';
@@ -33,8 +33,8 @@ window.onload = () => {
         xhr.onreadystatechange = function() {
             if (xhr.readyState === xhr.DONE) {
                 if (xhr.status === 200 || xhr.status === 201) {
-                    console.log(xhr.responseText);
-                    outputMemo(null, 'register');
+                    const registeredMemoId = xhr.responseText;
+                    outputMemo(null, 'register', registeredMemoId);
                 }
                 else {
                     console.error(xhr.responseText);
@@ -85,13 +85,13 @@ window.onload = () => {
         if (event.target.getAttribute('class') !== 'memo-del-btn') {
             return;
         }
-        var memoId = event.target.getAttribute('id');
+        const memoId = event.target.getAttribute('id').replace('memo-num-','');
 
         const xhr = new XMLHttpRequest();
         xhr.onreadystatechange = function() {
             if (xhr.readyState === xhr.DONE) {
                 if (xhr.status === 200 || xhr.status === 201) {
-                    selectMemo();
+                    deleteMemoFromDOM(memoId);
                 }
                 else {
                     console.error(xhr.response);
@@ -101,6 +101,11 @@ window.onload = () => {
         xhr.open('DELETE', HOST_ADDRESS + '/memo/delete/' + memoId);
         // xhr.setRequestHeader('Content-Type', 'application/json');
         xhr.send();
+    }
+
+    function deleteMemoFromDOM(memoId) {
+        // DOM에서 memo id에 해당하는 요소를 기준으로 첫번째 .memo-item 요소를 가져온다.
+        var $memoItemElem = document.querySelector('#memo-num-' + memoId).closest('.memo-item').remove();
     }
 
 }

--- a/src/test/java/com/zetta/memo/page/memo/MemoRepositoryTest.java
+++ b/src/test/java/com/zetta/memo/page/memo/MemoRepositoryTest.java
@@ -9,8 +9,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
 public class MemoRepositoryTest {
@@ -26,9 +26,9 @@ public class MemoRepositoryTest {
         memo.setWriterId(1);
         memo.setMemo("insert 테스트 입니다.");
 
-        boolean insertResult = memoMapper.insertMemo(memo);
+        memoMapper.insertMemo(memo);
 
-        assertTrue(insertResult);
+        assertNotNull(memo.getId());
 
         MemoDTO.Search search = new MemoDTO.Search();
         List<MemoDTO> memoList = memoMapper.selectMemo(search);
@@ -43,20 +43,17 @@ public class MemoRepositoryTest {
         memo.setWriterId(1);
         memo.setMemo("insert 테스트 입니다.");
 
-        boolean insertResult = memoMapper.insertMemo(memo);
+        memoMapper.insertMemo(memo);
 
-        assertTrue(insertResult);
+        assertNotNull(memo.getId());
 
         MemoDTO.Search search = new MemoDTO.Search();
         search.setMemo("테스트");
 
         List<MemoDTO> list = memoMapper.selectMemo(search);
 
-        list.stream().forEach(dto -> {
-            assertThat(dto.getMemo()).contains("테스트");
-        });
+        list.stream().forEach(dto -> assertThat(dto.getMemo()).contains("테스트"));
 
     }
-
 
 }


### PR DESCRIPTION
- 메모 삭제시, 기존에는 삭제 요청 후, 전체 메모를 다시 로드하는 방식.
- 변경함. 삭제 요청 후 성공 응답이 오면. DOM에서 해당 메모만 삭제.
- 삭제후, 메모 중복 표기 버그 수정.